### PR TITLE
avoid single quotes to fix npm build on windows

### DIFF
--- a/entity-browser-frontend/package.json
+++ b/entity-browser-frontend/package.json
@@ -9,10 +9,10 @@
     "clean": "rimraf dist",
     "test": "karma start",
     "start": "webpack serve --config=webpack/development.config.js --mode development --progress --inline",
-    "lint": "eslint '**/*.js' --quiet=true",
-    "build": "npm run parallel -- 'npm run build:browser' ",
+    "lint": "eslint \"**/*.js\" --quiet=true",
+    "build": "npm run parallel -- \"npm run build:browser\" ",
     "prebuild": "npm install && npm run lint && npm run clean",
-    "build:browser": "npm run parallel -- 'npm run build:browser:js'",
+    "build:browser": "npm run parallel -- \"npm run build:browser:js\"",
     "build:browser:js": "webpack --config=webpack/production.config.js",
     "parallel": "concurrently --no-color"
   },


### PR DESCRIPTION
Fixes npm build errors on Windows command line (PowerShell / bat)